### PR TITLE
Replace count with for each

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -36,8 +36,8 @@ resource "aws_iam_group" "default" {
 
 # https://www.terraform.io/docs/providers/aws/r/iam_user_group_membership.html
 resource "aws_iam_user_group_membership" "default" {
-  count  = local.enabled && length(var.user_names) > 0 ? length(var.user_names) : 0
-  user   = element(var.user_names, count.index)
+  for_each  = toset(var.user_names)
+  user   = each.key
   groups = [join("", aws_iam_group.default.*.id)]
 }
 


### PR DESCRIPTION
Replaces the list of users with a set. This will make it so that changing the order of the resources (by adding, sorting, or removing) no longer recreates the resources after an initial run.

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create
  - destroy

Terraform will perform the following actions:

  # module.organization_readonly_access_group.aws_iam_user_group_membership.default will be destroyed
  - resource "aws_iam_user_group_membership" "default" {
      - groups = [
          - "measurabl-root-iam-readonly",
        ] -> null
      - id     = "terraform-20200722141759490700000018" -> null
      - user   = "AdrianIrwin" -> null
    }

  # module.organization_readonly_access_group.aws_iam_user_group_membership.default[1] will be destroyed
  - resource "aws_iam_user_group_membership" "default" {
      - groups = [
          - "measurabl-root-iam-readonly",
        ] -> null
      - id     = "terraform-2020072214175977310000001f" -> null
      - user   = "AJZane" -> null
    }
```
...
```
  # module.organization_readonly_access_group.aws_iam_user_group_membership.default["AJZane"] will be created
  + resource "aws_iam_user_group_membership" "default" {
      + groups = [
          + "measurabl-root-iam-readonly",
        ]
      + id     = (known after apply)
      + user   = "AJZane"
    }

  # module.organization_readonly_access_group.aws_iam_user_group_membership.default["AdrianIrwin"] will be created
  + resource "aws_iam_user_group_membership" "default" {
      + groups = [
          + "measurabl-root-iam-readonly",
        ]
      + id     = (known after apply)
      + user   = "AdrianIrwin"
    }
```